### PR TITLE
Fix cast of APDU res to byte array (aka string)

### DIFF
--- a/virtualsmartcard/src/vpicc/virtualsmartcard/cards/Relay.py
+++ b/virtualsmartcard/src/vpicc/virtualsmartcard/cards/Relay.py
@@ -131,4 +131,4 @@ class RelayOS(SmartcardOS):
             rapdu = rapdu + [sw1, sw2]
 
         # return the response APDU as string
-        return "".join([bytes(b) for b in rapdu])
+        return "".join(map(chr, rapdu))


### PR DESCRIPTION
Hi,

We are using the virtual smart card reader to remotely authenticate using a smart card. We ran into problems because the APDU response was an unrecognised error. We found that when casting the relayed APDU response into a string to send to the VPICC, the string cast was not correct.

```
>>> # An example APDU response for a command CMD=[0x00, 0xCA, 0x01, 0xA0]
>>> res=[77, 121, 69, 73, 68, 4, 0, 0, 0, 0, 113, 105, 1, 86, 80, 152, 115, 149, 1, 14, 144, 0]
>>> 
>>> "".join([bytes(b) for b in res]) # The old code - incorrect
'7712169736840000113105186801521151491141440'
>>> 
>>> # Now the correct version
>>> map(chr, res) # Map the integer bytes first into bytes
['M', 'y', 'E', 'I', 'D', '\x04', '\x00', '\x00', '\x00', '\x00', 'q', 'i', '\x01', 'V', 'P', '\x98', 's', '\x95', '\x01', '\x0e', '\x90', '\x00']
>>> "".join(map(chr, res)) # Then concatenate the bytes into a string (aka a list of bytes)
'MyEID\x04\x00\x00\x00\x00qi\x01VP\x98s\x95\x01\x0e\x90\x00'
>>> 
```

Best wishes,

Rob and Iris